### PR TITLE
Fix order of implode() function parameters

### DIFF
--- a/src/Multitenancy.php
+++ b/src/Multitenancy.php
@@ -162,7 +162,7 @@ class Multitenancy
 
         // Combine multiple level of domains into 1 string
         // ex: back to masterdomain.test
-        $subdomain = implode($subdomains, '.');
+        $subdomain = implode('.', $subdomains);
 
         return $subdomain;
     }


### PR DESCRIPTION
Surprisingly, implode() with reversed order of arguments worked 🤯